### PR TITLE
Fix for form resetting after submit button is pressed.

### DIFF
--- a/app/pages/account/index.js
+++ b/app/pages/account/index.js
@@ -13,17 +13,17 @@ import Onboarding from '../../components/accounts/Onboarding';
 import Layout from '../../components/Layout';
 
 function Account() {
-  const [isLoading, setIsLoading] = React.useState(true);
+  // const [isLoading, setIsLoading] = React.useState(true);
   const { user } = useUser();
 
   const router = useRouter();
 
   const { account } = React.useContext(AccountContext);
 
-  if (!isLoading && !account) {
-    router.push('/');
-    return null;
-  }
+  // if (!isLoading && !account) {
+  //   router.push('/');
+  //   return null;
+  // }
 
   const handleFormSubmit = async (submission) => {
     const { formData: data } = submission;
@@ -32,7 +32,7 @@ function Account() {
       body: JSON.stringify({ ...data, email: account.email }),
     });
     const json = await res.json();
-    setIsLoading(false);
+    // setIsLoading(false);
   };
 
   let content = (


### PR DESCRIPTION
# Title
Fix for form resetting to original after changes are submitted. (#23)

## Changes

- Stopped Account page's state from changing after form is submitted - for some reason, when the account page's state was altered when the updated information for the startup was submitted, it was causing the form to revert to the initial version that was displayed to the user. Currently, the only change I made is to remove isLoading - the specific line that was causing this issue to happen was when we called `setIsLoading(false)` after the form submitted. This probably isn't the *best* solution, so I was curious if anyone had suggestions on a better way to implement this - if not, I'll just delete the commented code.

## Screenshots (if applicable)
N/A